### PR TITLE
Add retryMs configurable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ cfn-tail --region eu-west-1 <stackname>
 
 Logging will stop if the stack creation or update completes or fails.
 
+### Optional Arguments
+
+- `--retryMs <number>` specifies the value in milliseconds to use for custom exponential backoff; defaults to `700`. Use this option if you frequently experience API throttling errors.
+- `--color <bool>` specifies whether to colorize the output; defaults to `true`
+
 ## Proxy support
 
 If you need support for HTTPS proxies. Install the `proxy-agent` package globally and set the correct environment variables.

--- a/index.js
+++ b/index.js
@@ -8,17 +8,19 @@
 
 var argv = require('minimist')(process.argv.slice(2), {
   "default": {
-    "color": true
+    "color": true,
+    "retryMs": 700
+    // Delays with maxRetries = 4: 700, 1400, 2800, 5600
   }
 });
 
 var stackName = argv._[0];
 var awsRegion = argv.region || process.env.AWS_DEFAULT_REGION;
 var color = argv.color;
+var retryMs = argv.retryMs;
 
 var AWS = require('aws-sdk');
-AWS.config.update({retryDelayOptions: {base: 700}});
-// Delays with maxRetries = 4: 700, 1400, 2800, 5600
+AWS.config.update({retryDelayOptions: {base: retryMs}});
 if (process.env.HTTPS_PROXY || process.env.https_proxy) {
   
   try {


### PR DESCRIPTION
Adds `--retryMs` optional command line argument support, which will allow a developer to customize the value used for exponential backoff of the AWS APIs. This will resolve issues for developers who run multiple CI jobs in parallel calling the CloudFormation APIs who experience API throttling errors.

Closes #2 